### PR TITLE
Separate CLI parsing from main process

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -43,9 +43,9 @@ def parse_predict():
 
     if args.weights is not None:
         argstate.weights = args.weights
-
     else:
         argstate.weights = config['train']['saved_weights_name']
+
     argstate.input = args.input
 
     return argstate
@@ -89,5 +89,5 @@ def parse_train():
     argstate.saved_weights_name = config['train']['saved_weights_name']
     argstate.debug = config['train']['debug']
     argstate.pretrained_weights = config['train']['pretrained_weights']
-    
+
     return argstate

--- a/cli.py
+++ b/cli.py
@@ -40,7 +40,9 @@ def parse_predict():
     argstate.max_box_per_image = config['model']['max_box_per_image']
     argstate.anchors = config['model']['anchors']
 
-    argstate.weights = args.weights if args.weights is not None else config[
-        'train']['saved_weights_name']
+    if args.weights is not None:
+        argstate.weights = args.weights
+    else:
+        argstate.weights = config['train']['saved_weights_name']
     argstate.input = args.input
     return argstate

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,41 @@
+# Parses input from command line arguments
+import argparse
+import json
+class ArgState: # Anonymous class used by the returned state
+    pass
+def parse_predict():
+    # This factors in command line arguments and config and merges them to
+    # produce a single configuration object
+    argparser = argparse.ArgumentParser(
+        description='Train and validate YOLO_v2 model on any dataset')
+
+    argparser.add_argument(
+        '-c',
+        '--conf',
+        help='path to configuration file')
+
+    argparser.add_argument(
+        '-w',
+        '--weights',
+        help='path to pretrained weights')
+
+    argparser.add_argument(
+        '-i',
+        '--input',
+        help='path to an image or an video (mp4 format)')
+
+    args = argparser.parse_args()
+    config_path = args.conf
+    with open(config_path) as config_buffer:
+        config = json.load(config_buffer)
+    print(config)
+    argstate = ArgState
+    argstate.architecture = config['model']['architecture']
+    argstate.input_size = config['model']['input_size']
+    argstate.labels = config['model']['labels']
+    argstate.max_box_per_image = config['model']['max_box_per_image']
+    argstate.anchors = config['model']['anchors']
+
+    argstate.weights = args.weights if args.weights is not None else config['train']['saved_weights_name']
+    argstate.input = args.input
+    return argstate

--- a/cli.py
+++ b/cli.py
@@ -29,9 +29,11 @@ def parse_predict():
         help='path to an image or an video (mp4 format)')
 
     args = argparser.parse_args()
+
     config_path = args.conf
     with open(config_path) as config_buffer:
         config = json.load(config_buffer)
+        
     argstate = ArgState
     argstate.architecture = config['model']['architecture']
     argstate.input_size = config['model']['input_size']
@@ -55,10 +57,13 @@ def parse_train():
         '-c',
         '--config',
         help='path to configuration file')
+
     args = argparser.parse_args()
+
     config_path = args.conf
     with open(config_path) as config_buffer:
         config = json.loads(config_buffer.read())
+
     argstate = ArgState
     argstate.train.annot_folder = config['train']['train_annot_folder']
     argstate.train.image_folder = config['train']['train_image_folder']

--- a/cli.py
+++ b/cli.py
@@ -33,7 +33,7 @@ def parse_predict():
     config_path = args.conf
     with open(config_path) as config_buffer:
         config = json.load(config_buffer)
-        
+
     argstate = ArgState
     argstate.architecture = config['model']['architecture']
     argstate.input_size = config['model']['input_size']
@@ -43,9 +43,11 @@ def parse_predict():
 
     if args.weights is not None:
         argstate.weights = args.weights
+
     else:
         argstate.weights = config['train']['saved_weights_name']
     argstate.input = args.input
+
     return argstate
 
 
@@ -87,4 +89,5 @@ def parse_train():
     argstate.saved_weights_name = config['train']['saved_weights_name']
     argstate.debug = config['train']['debug']
     argstate.pretrained_weights = config['train']['pretrained_weights']
+    
     return argstate

--- a/cli.py
+++ b/cli.py
@@ -32,7 +32,6 @@ def parse_predict():
     config_path = args.conf
     with open(config_path) as config_buffer:
         config = json.load(config_buffer)
-    print(config)
     argstate = ArgState
     argstate.architecture = config['model']['architecture']
     argstate.input_size = config['model']['input_size']

--- a/cli.py
+++ b/cli.py
@@ -45,3 +45,40 @@ def parse_predict():
         argstate.weights = config['train']['saved_weights_name']
     argstate.input = args.input
     return argstate
+
+def parse_train():
+    argparser = argparse.ArgumentParser(
+        description='Train and validate YOLO_v2 model on any dataset')
+
+    argparser.add_argument(
+        '-c',
+        '--config',
+        help='path to configuration file')
+    args = argparser.parse_args()
+    config_path = args.conf
+    with open(config_path) as config_buffer:
+        config = json.loads(config_buffer.read())
+    argstate = ArgState
+    argstate.annot_folder = config['train']['train_annot_folder']
+    argstate.image_folder = config['train']['train_image_folder']
+    argstate.labels = config['model']['labels']
+    argstate.v_annot_folder = config['valid']['valid_annot_folder']
+    argstate.v_image_folder = config['valid']['valid_image_folder']
+    argstate.architecture = config['model']['architecture']
+    argstate.input_size = config['model']['input_size']
+    argstate.mbpi = config['model']['max_box_per_image']
+    argstate.anchors = config['model']['anchors']
+    argstate.train_times = config['train']['train_times']
+    argstate.valid_times = config['valid']['valid_times']
+    argstate.nb_epoch = config['train']['nb_epoch']
+    argstate.learning_rate = config['train']['learning_rate']
+    argstate.batch_size = config['train']['batch_size']
+    argstate.warmup_bs = config['train']['warmup_batches']
+    argstate.object_scale = config['train']['object_scale']
+    argstate.no_object_scale = config['train']['no_object_scale']
+    argstate.coord_scale = config['train']['coord_scale']
+    argstate.class_scale = config['train']['class_scale']
+    argstate.saved_weights_name = config['train']['saved_weights_name']
+    argstate.debug = config['train']['debug']
+    argstate.pretrained_weights = config['train']['pretrained_weights']
+    return argstate

--- a/cli.py
+++ b/cli.py
@@ -59,17 +59,17 @@ def parse_train():
     with open(config_path) as config_buffer:
         config = json.loads(config_buffer.read())
     argstate = ArgState
-    argstate.annot_folder = config['train']['train_annot_folder']
-    argstate.image_folder = config['train']['train_image_folder']
+    argstate.train.annot_folder = config['train']['train_annot_folder']
+    argstate.train.image_folder = config['train']['train_image_folder']
     argstate.labels = config['model']['labels']
-    argstate.v_annot_folder = config['valid']['valid_annot_folder']
-    argstate.v_image_folder = config['valid']['valid_image_folder']
+    argstate.valid.annot_folder = config['valid']['valid_annot_folder']
+    argstate.valid.image_folder = config['valid']['valid_image_folder']
     argstate.architecture = config['model']['architecture']
     argstate.input_size = config['model']['input_size']
     argstate.mbpi = config['model']['max_box_per_image']
     argstate.anchors = config['model']['anchors']
-    argstate.train_times = config['train']['train_times']
-    argstate.valid_times = config['valid']['valid_times']
+    argstate.train.times = config['train']['train_times']
+    argstate.valid.times = config['valid']['valid_times']
     argstate.nb_epoch = config['train']['nb_epoch']
     argstate.learning_rate = config['train']['learning_rate']
     argstate.batch_size = config['train']['batch_size']

--- a/cli.py
+++ b/cli.py
@@ -46,6 +46,7 @@ def parse_predict():
     argstate.input = args.input
     return argstate
 
+
 def parse_train():
     argparser = argparse.ArgumentParser(
         description='Train and validate YOLO_v2 model on any dataset')

--- a/cli.py
+++ b/cli.py
@@ -1,8 +1,12 @@
 # Parses input from command line arguments
 import argparse
 import json
-class ArgState: # Anonymous class used by the returned state
+
+
+class ArgState:  # Anonymous class used by the returned state
     pass
+
+
 def parse_predict():
     # This factors in command line arguments and config and merges them to
     # produce a single configuration object
@@ -36,6 +40,7 @@ def parse_predict():
     argstate.max_box_per_image = config['model']['max_box_per_image']
     argstate.anchors = config['model']['anchors']
 
-    argstate.weights = args.weights if args.weights is not None else config['train']['saved_weights_name']
+    argstate.weights = args.weights if args.weights is not None else config[
+        'train']['saved_weights_name']
     argstate.input = args.input
     return argstate

--- a/cli.py
+++ b/cli.py
@@ -15,7 +15,7 @@ def parse_predict():
 
     argparser.add_argument(
         '-c',
-        '--conf',
+        '--config',
         help='path to configuration file')
 
     argparser.add_argument(

--- a/frontend.py
+++ b/frontend.py
@@ -1,12 +1,22 @@
 from keras.models import Model
-from keras.layers import Reshape, Activation, Conv2D, Input, MaxPooling2D, BatchNormalization, Flatten, Dense, Lambda
+from keras.layers import Activation
+from keras.layers import BatchNormalization
+from keras.layers import Conv2D
+from keras.layers import Dense
+from keras.layers import Flatten
+from keras.layers import Input
+from keras.layers import Lambda
+from keras.layers import MaxPooling2D
+from keras.layers import Reshape
 from keras.layers.advanced_activations import LeakyReLU
 import tensorflow as tf
 import numpy as np
 import cv2
 from keras.applications.mobilenet import MobileNet
 from keras.layers.merge import concatenate
-from keras.optimizers import SGD, Adam, RMSprop
+from keras.optimizers import Adam
+from keras.optimizers import RMSprop
+from keras.optimizers import SGD
 from preprocessing import BatchGenerator
 from keras.callbacks import EarlyStopping, ModelCheckpoint, TensorBoard
 from utils import BoundBox

--- a/predict.py
+++ b/predict.py
@@ -12,7 +12,7 @@ os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
 
-def _main_(argstate):
+def main(argstate):
 
     weights_path = argstate.weights
     image_path = argstate.input
@@ -79,4 +79,4 @@ def _main_(argstate):
 
 if __name__ == '__main__':
     argstate = cli.parse_predict()
-    _main_(argstate)
+    main(argstate)

--- a/predict.py
+++ b/predict.py
@@ -11,6 +11,7 @@ from frontend import YOLO
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
+
 def _main_(argstate):
 
     weights_path = argstate.weights

--- a/predict.py
+++ b/predict.py
@@ -1,55 +1,30 @@
 #! /usr/bin/env python
 
-import argparse
+import cli
 import os
 import cv2
 import numpy as np
 from tqdm import tqdm
-from preprocessing import parse_annotation
 from utils import draw_boxes
 from frontend import YOLO
-import json
 
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
-argparser = argparse.ArgumentParser(
-    description='Train and validate YOLO_v2 model on any dataset')
+def _main_(argstate):
 
-argparser.add_argument(
-    '-c',
-    '--conf',
-    help='path to configuration file')
-
-argparser.add_argument(
-    '-w',
-    '--weights',
-    help='path to pretrained weights')
-
-argparser.add_argument(
-    '-i',
-    '--input',
-    help='path to an image or an video (mp4 format)')
-
-
-def _main_(args):
-
-    config_path = args.conf
-    weights_path = args.weights
-    image_path = args.input
-
-    with open(config_path) as config_buffer:
-        config = json.load(config_buffer)
+    weights_path = argstate.weights
+    image_path = argstate.input
 
     ###############################
     #   Make the model
     ###############################
 
-    yolo = YOLO(architecture=config['model']['architecture'],
-                input_size=config['model']['input_size'],
-                labels=config['model']['labels'],
-                max_box_per_image=config['model']['max_box_per_image'],
-                anchors=config['model']['anchors'])
+    yolo = YOLO(architecture=argstate.architecture,
+                input_size=argstate.input_size,
+                labels=argstate.labels,
+                max_box_per_image=argstate.max_box_per_image,
+                anchors=argstate.anchors)
 
     ###############################
     #   Load trained weights
@@ -85,7 +60,7 @@ def _main_(args):
             _, image = video_reader.read()
 
             boxes = yolo.predict(image)
-            image = draw_boxes(image, boxes, config['model']['labels'])
+            image = draw_boxes(image, boxes, argstate.labels)
 
             video_writer.write(np.uint8(image))
 
@@ -94,7 +69,7 @@ def _main_(args):
     else:
         image = cv2.imread(image_path)
         boxes = yolo.predict(image)
-        image = draw_boxes(image, boxes, config['model']['labels'])
+        image = draw_boxes(image, boxes, argstate.labels)
 
         print(len(boxes), 'boxes are found')
 
@@ -102,5 +77,5 @@ def _main_(args):
 
 
 if __name__ == '__main__':
-    args = argparser.parse_args()
-    _main_(args)
+    argstate = cli.parse_predict()
+    _main_(argstate)

--- a/train.py
+++ b/train.py
@@ -73,7 +73,8 @@ def _main_(args):
     ###############################
 
     if os.path.exists(config['train']['pretrained_weights']):
-        print("Loading pre-trained weights in", config['train']['pretrained_weights'])
+        print("Loading pre-trained weights in",
+              config['train']['pretrained_weights'])
         yolo.load_weights(config['train']['pretrained_weights'])
 
     ###############################

--- a/train.py
+++ b/train.py
@@ -14,6 +14,7 @@ from frontend import YOLO
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
+
 def main(argstate):
     ###############################
     #   Parse the annotations

--- a/train.py
+++ b/train.py
@@ -20,14 +20,14 @@ def main(argstate):
     ###############################
 
     # parse annotations of the training set
-    train_imgs, train_labels = parse_annotation(argstate.annot_folder,
-                                                argstate.image_folder,
+    train_imgs, train_labels = parse_annotation(argstate.train.annot_folder,
+                                                argstate.train.image_folder,
                                                 argstate.labels)
 
     # parse annotations of the validation set, if any, otherwise split the training set
     if os.path.exists(argstate.v_annot_folder):
-        valid_imgs, valid_labels = parse_annotation(argstate.v_annot_folder,
-                                                    argstate.v_image_folder,
+        valid_imgs, valid_labels = parse_annotation(argstate.valid.annot_folder,
+                                                    argstate.valid.image_folder,
                                                     argstate.labels)
     else:
         train_valid_split = int(0.8*len(train_imgs))


### PR DESCRIPTION
Fixes #6.

I separated configuration handling and command argument parsing to a different module. Essentially, this allows us to funnel together inputs from the JSON configuration file and the command line, so we can allow one to take precedence over the other, and so that the predict module doesn't have ugly sets of dictionary sub-indexes.