### PR TITLE
Fix Argstate persistence error

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -30,11 +30,11 @@ def parse_predict():
 
     args = argparser.parse_args()
 
-    config_path = args.conf
+    config_path = args.config
     with open(config_path) as config_buffer:
         config = json.load(config_buffer)
 
-    argstate = ArgState
+    argstate = ArgState()
     argstate.architecture = config['model']['architecture']
     argstate.input_size = config['model']['input_size']
     argstate.labels = config['model']['labels']
@@ -62,11 +62,13 @@ def parse_train():
 
     args = argparser.parse_args()
 
-    config_path = args.conf
+    config_path = args.config
     with open(config_path) as config_buffer:
         config = json.loads(config_buffer.read())
 
-    argstate = ArgState
+    argstate = ArgState()
+    argstate.train = ArgState()
+    argstate.valid = ArgState()
     argstate.train.annot_folder = config['train']['train_annot_folder']
     argstate.train.image_folder = config['train']['train_image_folder']
     argstate.labels = config['model']['labels']


### PR DESCRIPTION
I realized that the 'train' and 'valid' subproperties of the argstate in cli.py caused an overlap of properties because they were directly modifying a class, not initializing a new one. This fixes that.